### PR TITLE
[ios] switch react native ios landscape-left/landscape-right mappings

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -186,10 +186,10 @@ RCT_EXPORT_METHOD(lockToLandscape)
   }
 }
 
-RCT_EXPORT_METHOD(lockToLandscapeLeft)
+RCT_EXPORT_METHOD(lockToLandscapeRight)
 {
   #if DEBUG
-    NSLog(@"Locked to Landscape Left");
+    NSLog(@"Locked to Landscape Right");
   #endif
     [Orientation setOrientation:UIInterfaceOrientationMaskLandscapeLeft];
     [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
@@ -199,10 +199,10 @@ RCT_EXPORT_METHOD(lockToLandscapeLeft)
 
 }
 
-RCT_EXPORT_METHOD(lockToLandscapeRight)
+RCT_EXPORT_METHOD(lockToLandscapeLeft)
 {
   #if DEBUG
-    NSLog(@"Locked to Landscape Right");
+    NSLog(@"Locked to Landscape Left");
   #endif
   [Orientation setOrientation:UIInterfaceOrientationMaskLandscapeRight];
   [[NSOperationQueue mainQueue] addOperationWithBlock:^ {


### PR DESCRIPTION
This PR changes the iOS implementation to lock to device orientation not interface orientation

https://developer.apple.com/documentation/uikit/uiinterfaceorientation

> Notice that UIDeviceOrientation.landscapeRight is assigned to UIInterfaceOrientation.landscapeLeft and UIDeviceOrientation.landscapeLeft is assigned to UIInterfaceOrientation.landscapeRight. The reason for this is that rotating the device requires rotating the content in the opposite direction.